### PR TITLE
Feature/setup base perique

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -52,6 +52,8 @@
 		<!-- Ignore missing type hints since we sometimes want to ignore them on hooks. -->
 		<exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing"/>
 		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
+		<!-- Allow fileblock to be after declare statements-->
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder" />
 	</rule>
 
 	<!-- Check that class comments exists. -->

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
         "test": "./vendor/bin/phpunit --coverage-clover coverage.xml --testdox",
         "coverage": "./vendor/bin/phpunit --coverage-html coverage-report --testdox",
         "analyse": "./vendor/bin/phpstan analyse src -l8",
-        "sniff": "./vendor/bin/phpcs src views -v",
-        "format": "./vendor/bin/phpcbf src views -v",
+        "sniff": "./vendor/bin/phpcs src -v",
+        "format": "./vendor/bin/phpcbf src -v",
         "all": "composer test && composer analyse && composer sniff",
         "internationalize": [
             "@makepot",

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     }],
     "autoload": {
         "psr-4": {
-            "PinkCrab\\X-Importer\\": "src"
+            "PinkCrab\\X_Importer\\": "src"
 
         },
         "files": []
     },
     "autoload-dev": {
         "psr-4": {
-            "PinkCrab\\X-Importer\\Tests\\": "tests"
+            "PinkCrab\\X_Importer\\Tests\\": "tests"
         }
     },
     "require-dev": {

--- a/config/registration.php
+++ b/config/registration.php
@@ -10,4 +10,8 @@
  * @since 0.1.0
  */
 
-return array();
+use PinkCrab\X_Importer\Admin\Settings_Page;
+
+return array(
+	Settings_Page::class,
+);

--- a/pinkcrab-x-importer.php
+++ b/pinkcrab-x-importer.php
@@ -22,9 +22,9 @@ if ( ! defined( 'WPINC' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$app = ( new App_Factory() )
-->module( \PinkCrab\Queue\Module\Perique_Queue::class )
-->module( \PinkCrab\Perique_Admin_Menu\Module\Admin_Menu::class )
+( new App_Factory() )
+	->module( \PinkCrab\Queue\Module\Perique_Queue::class )
+	->module( \PinkCrab\Perique_Admin_Menu\Module\Admin_Menu::class )
 	->module(
 		BladeOne::class,
 		function ( BladeOne $blade ): BladeOne {
@@ -33,7 +33,7 @@ $app = ( new App_Factory() )
 					$engine->directive(
 						'__',
 						function ( $e ) {
-							return "<?php echo __( $e, 'pc-cm' ); ?>";
+							return "<?php echo __( $e, 'pc-x' ); ?>";
 						}
 					)
 					->set_comment_mode( PinkCrab_BladeOne::COMMENT_NONE )
@@ -49,4 +49,4 @@ $app = ( new App_Factory() )
 	->di_rules( require __DIR__ . '/config/dependencies.php' )
 	->app_config( require __DIR__ . '/config/settings.php' )
 	->registration_classes( require __DIR__ . '/config/registration.php' )
-->boot();
+	->boot();

--- a/pinkcrab-x-importer.php
+++ b/pinkcrab-x-importer.php
@@ -9,3 +9,44 @@
  * Requires at least: 6.1
  * Requires PHP: 7.4
  */
+
+use PinkCrab\BladeOne\BladeOne;
+use PinkCrab\BladeOne\BladeOne_Engine;
+use PinkCrab\BladeOne\PinkCrab_BladeOne;
+use PinkCrab\Perique\Application\App_Factory;
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$app = ( new App_Factory() )
+->module( \PinkCrab\Queue\Module\Perique_Queue::class )
+->module( \PinkCrab\Perique_Admin_Menu\Module\Admin_Menu::class )
+	->module(
+		BladeOne::class,
+		function ( BladeOne $blade ): BladeOne {
+			$blade->config(
+				function ( BladeOne_Engine $engine ) {
+					$engine->directive(
+						'__',
+						function ( $e ) {
+							return "<?php echo __( $e, 'pc-cm' ); ?>";
+						}
+					)
+					->set_comment_mode( PinkCrab_BladeOne::COMMENT_NONE )
+					->set_mode( PinkCrab_BladeOne::MODE_SLOW );
+					return $engine;
+				}
+			);
+
+			return $blade;
+		}
+	)
+	->default_setup()
+	->di_rules( require __DIR__ . '/config/dependencies.php' )
+	->app_config( require __DIR__ . '/config/settings.php' )
+	->registration_classes( require __DIR__ . '/config/registration.php' )
+->boot();

--- a/src/Admin/Settings_Page.php
+++ b/src/Admin/Settings_Page.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Settings Page for the plugin.
+ *
+ * @package PinkCrab\X_Importer
+ *
+ * @since 0.1.0
+ */
+
+namespace PinkCrab\X_Importer\Admin;
+
+use PinkCrab\Perique\Application\App_Config;
+use PinkCrab\Perique_Admin_Menu\Page\Page;
+use PinkCrab\Perique_Admin_Menu\Page\Menu_Page;
+
+/**
+ * The settings page for the plugin.
+ */
+class Settings_Page extends Menu_Page {
+
+	/**
+	 * The page slug.
+	 *
+	 * @var string
+	 */
+	protected string $page_slug = 'pc_x_importer';
+
+	/**
+	 * The parent slug.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $parent_slug = 'tools.php';
+
+	/**
+	 * The capability required to view the page.
+	 *
+	 * @var string
+	 */
+	protected string $capability = 'manage_options';
+
+	/**
+	 * The page menu position.
+	 *
+	 * @var integer|null
+	 */
+	protected ?int $position = 12;
+
+	/**
+	 * Access to App_Config
+	 *
+	 * @var \PinkCrab\Perique\Application\App_Config
+	 */
+	protected $app_config;
+
+	/**
+	 * Sets up the page.
+	 *
+	 * @param \PinkCrab\Perique\Application\App_Config $app_config The app config.
+	 */
+	public function __construct( App_Config $app_config ) {
+		$this->app_config = $app_config;
+
+		// Set the titles.
+		$this->menu_title    = _x( 'X Importer', 'Settings Page Menu Title', 'pc-x' );
+		$this->page_title    = _x( 'PinkCrab X Importer', 'Settings Page Page Title', 'pc-x' );
+		$this->view_template = 'admin.settings-page';
+
+		$this->view_data = array(
+			'page'   => $this,
+			'plugin' => $this->app_config,
+		);
+	}
+
+	/**
+	 * Set the page template and data.
+	 *
+	 * @param Page $page The page object.
+	 *
+	 * @return void
+	 */
+	public function load( Page $page ): void {
+	}
+}

--- a/views/admin/settings-page.blade.php
+++ b/views/admin/settings-page.blade.php
@@ -1,0 +1,4 @@
+<div class="wrap">
+    <h1>{{ $page->page_title() }}</h1>
+    placeholder
+</div>


### PR DESCRIPTION
This pull request includes several important changes to the `PinkCrab\X_Importer` plugin, focusing on improving the configuration, autoloading, and adding a new settings page. The most notable changes are summarized below:

### Configuration and Autoloading:

* [`.phpcs.xml`](diffhunk://#diff-e62fd5e0887483aa43041a31ce6deb93282f826f0cf3be6a422dbd3c7d4ed120R55-R56): Added an exclusion rule to allow file block comments to appear after declare statements.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L16-R23): Updated the namespace separator from `-` to `_` in the autoload and autoload-dev sections.

### Plugin Initialization:

* [`pinkcrab-x-importer.php`](diffhunk://#diff-609ad666e14784c92227547f314cb72d8cc507cb507e42693ba80d1f330cc81aR12-R52): Added multiple `use` statements for required classes, included a check to abort if the file is called directly, and configured the application using `App_Factory`.

### Settings Page:

* [`config/registration.php`](diffhunk://#diff-b9d3a1e26390d5c92a23afeee588ae99cdfa97a9b97381b9ce8fa76712ff133eL13-R17): Registered the `Settings_Page` class in the return array.
* [`src/Admin/Settings_Page.php`](diffhunk://#diff-73f979fef5517db262bb241d22b93fd4f1635fad39c589e9aefaa0d3a208248cR1-R87): Created a new `Settings_Page` class extending `Menu_Page`, setting up the page with necessary properties and methods.
* [`views/admin/settings-page.blade.php`](diffhunk://#diff-df3f9439c595cedc47f5b0e2f548fd2ad25d73e3fefdb1b68ab149fcad2235ceR1-R4): Added a basic Blade template for the settings page with a placeholder.