### PR TITLE
Added video file test with some additional checks to ensure videos ar…

### DIFF
--- a/tests/Unit/Media/Test_Media_Upload.php
+++ b/tests/Unit/Media/Test_Media_Upload.php
@@ -172,4 +172,24 @@ class Test_Media_Upload extends WP_UnitTestCase {
         // Clear the filter.
         \remove_all_filters( 'pre_http_request' );
     }
+
+	/** @testdox It should be possible to upload a video file and have it added to the media library */
+	public function test_import_video_from_url(): void {
+		$media_upload = new Media_Upload();
+		$result       = $media_upload->create_from_remote_path( PC_X_IMPORTER_VALID_VIDEO_URL, 'video.mp4' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'attachment_id', $result );
+		$this->assertIsNumeric( $result['attachment_id'] );
+		$this->assertGreaterThan( 0, $result['attachment_id'] );
+
+		// Check the paths.
+		$this->assertArrayHasKey( 'full_path', $result );
+		$this->assertSame( PC_X_IMPORTER_FIXTURES . 'uploads/video.mp4', $result['full_path'] );
+		$this->assertArrayHasKey( 'full_url', $result );
+
+		// Sizes should be empty
+		$this->assertArrayHasKey( 'sizes', $result );
+		$this->assertEmpty( $result['sizes'] );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,8 +12,8 @@ require_once getenv( 'WP_PHPUNIT__DIR' ) . '/includes/functions.php';
 define( 'PC_X_IMPORTER_DIR', dirname( __DIR__ ) );
 define( 'PC_X_IMPORTER_FIXTURES', __DIR__ . '/fixtures/' );
 define( 'PC_X_IMPORTER_TEST_ROOT', __DIR__ . '/' );
-define( 'PC_X_IMPORTER_VALID_IMG_URL', 'https://raw.githubusercontent.com/Pink-Crab/X-Importer/refs/heads/feature/create-import-tweet-events/tests/fixtures/data/bird.jpeg' );
-define( 'PC_X_IMPORTER_VALID_VIDEO_URL', 'https://raw.githubusercontent.com/Pink-Crab/X-Importer/refs/heads/feature/create-import-tweet-events/tests/fixtures/data/video.mp4' );
+define( 'PC_X_IMPORTER_VALID_IMG_URL', 'https://github.com/Pink-Crab/X-Importer/raw/refs/heads/develop/tests/fixtures/data/bird.jpeg' );
+define( 'PC_X_IMPORTER_VALID_VIDEO_URL', 'https://github.com/Pink-Crab/X-Importer/raw/refs/heads/develop/tests/fixtures/data/video.mp4' );
 
 // Load all environment variables into $_ENV
 try {


### PR DESCRIPTION
…e videos

This pull request includes various changes to the `src/Media/Media_Upload.php` file for handling remote file uploads and adds new test cases to ensure the functionality. Additionally, it updates the URLs in the `tests/bootstrap.php` file. The most important changes include adding a new method to handle MIME type checks, improving the handling of remote file content retrieval, and adding a new test for video file uploads.

Improvements to handling remote file uploads:

* [`src/Media/Media_Upload.php`](diffhunk://#diff-4a7330df380b72f8ca905d7bd8cd7a4b81973d5370c0c3d0ab653eff9adc2738R212-R230): Added a new method `get_mime_type` to handle MIME type checks for files that return as `application/octet-stream`. This method uses the `finfo` class to determine the correct MIME type.
* [`src/Media/Media_Upload.php`](diffhunk://#diff-4a7330df380b72f8ca905d7bd8cd7a4b81973d5370c0c3d0ab653eff9adc2738L180-R199): Improved the `get_remote_file_contents` method to include a check for `application/octet-stream` and use the new `get_mime_type` method to determine the correct MIME type.

Test enhancements:

* [`tests/Unit/Media/Test_Media_Upload.php`](diffhunk://#diff-2a1843bda59f942a60838061cf5e6c8ce742d06adf83e8e032caed5a69224830R175-R194): Added a new test `test_import_video_from_url` to ensure that video files can be uploaded and added to the media library correctly. The test checks various aspects of the upload result, including the attachment ID, file paths, and sizes.

URL updates:

* [`tests/bootstrap.php`](diffhunk://#diff-96a82592013e5f4b91e682332583b7a4a6ca1ff0431d267c61179b1a21b167daL15-R16): Updated the URLs for valid image and video files to point to the `develop` branch instead of the `feature/create-import-tweet-events` branch.

Minor improvements:

* [`src/Media/Media_Upload.php`](diffhunk://#diff-4a7330df380b72f8ca905d7bd8cd7a4b81973d5370c0c3d0ab653eff9adc2738L108-R110): Modified the `create_from_remote_path` method to check if the `sizes` key exists in the `attachment_data` array before mapping sizes, defaulting to an empty array if it doesn't exist.